### PR TITLE
[Synapse Serverless Workbook] Fix inconsistent unit labeling on "Data Processed By User" pie chart

### DIFF
--- a/Monitor_Workbooks/SynapseServerlessWorkbook.workbook
+++ b/Monitor_Workbooks/SynapseServerlessWorkbook.workbook
@@ -533,23 +533,35 @@
             "name": "Queries by Query Type"
           },
           {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "//Queries by completion type\r\nSynapseBuiltinSqlPoolRequestsEnded\r\n| where _ResourceId in~ ({Synapse})\r\n| project BytesProcessed=Properties.dataProcessedBytes,tostring(Identity)\r\n| summarize sum(toint(BytesProcessed)) by Identity\r\n| render piechart \r\n\r\n",
-              "size": 3,
-              "showAnalytics": true,
-              "title": "Data Processed By User",
-              "timeContextFromParameter": "TimeRange",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "crossComponentResources": [
-                "{LogAnalyticsWorkspace}"
-              ]
-            },
-            "customWidth": "33",
-            "showPin": true,
-            "name": "Data Processed By User"
+             "type":3,
+             "content":{
+                "version":"KqlItem/1.0",
+                "query":"//Queries by completion type\r\nSynapseBuiltinSqlPoolRequestsEnded\r\n| where _ResourceId in~ ({Synapse})\r\n| project Gb = todouble(Properties.dataProcessedBytes) / 1000000000, Identity\r\n| summarize round(sum(Gb), 1) by IdentityString = tostring(Identity)\r\n| render piechart\r\n\r\n",
+                "size":3,
+                "showAnalytics":true,
+                "title":"Data Processed By User",
+                "timeContextFromParameter":"TimeRange",
+                "queryType":0,
+                "resourceType":"microsoft.operationalinsights/workspaces",
+                "chartSettings":{
+                   "yAxis":[
+                      "sum_Gb"
+                   ],
+                   "ySettings":{
+                      "numberFormatSettings":{
+                         "unit":5,
+                         "options":{
+                            "style":"decimal",
+                            "useGrouping":true,
+                            "minimumFractionDigits":1
+                         }
+                      }
+                   }
+                }
+             },
+             "customWidth":"33",
+             "showPin":true,
+             "name":"Data Processed By User"
           },
           {
             "type": 3,


### PR DESCRIPTION

**What does this PR do?**  
Updates the "Data Processed By User" pie chart to consistently display units of measurement.

**Why is this change necessary?**
The current implementation can give wrong impressions about the amount of data processed, and this change ensures accurate labeling.

**How does this change work?** 
The query now summarizes data by GB, and formatting changes have been made to adjust the labeling.

**What are the benefits of this change?** 
The graph becomes easier to read and understand, with consistent unit labeling.

**Are there any breaking changes?**
No, this is not a breaking change.

**What testing has been done?** 
I tested the updated graph on a platform I use. Unfortunately I can not provide screen shots as this would reveal user's identity. To verify the change the reviewer can copy and paste the template into their workspace and verify the graph's visual and template formatting.

**Any related issues or PRs?** 
None 

**Changes Summary**

* Updated query to summarize data by GB
* Changed formatting to adjust labeling
* Screenshots/Videos: Not available
